### PR TITLE
docs(html-head): fill in resource hints and meta TODOs

### DIFF
--- a/docs/developing/programming-language/html/html-head.mdx
+++ b/docs/developing/programming-language/html/html-head.mdx
@@ -8,11 +8,45 @@ How to structure the `<head>` of an HTML document.
 
 Order matters, this document will illustrate each section in the order they should appear.
 
-TODO:
+## Resource Hints
 
-- `prefetch`
-- `preconnect`
-- `preload`
+Resource hints tell the browser about connections and assets needed ahead of time.
+
+### `preconnect`
+
+Establishes a connection (DNS + TCP + TLS) to an external origin early. Use for third-party origins that serve critical resources.
+
+```html
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+```
+
+### `dns-prefetch`
+
+Resolves DNS for an origin without opening a connection. Lower-cost fallback for browsers that don't support `preconnect`, or for less-critical third parties.
+
+```html
+<link rel="dns-prefetch" href="https://example.com" />
+```
+
+### `preload`
+
+Fetches a resource needed for the **current page** at high priority. Always include an `as` attribute so the browser applies correct request headers and CSP.
+
+```html
+<link rel="preload" href="/fonts/inter.woff2" as="font" type="font/woff2" crossorigin />
+<link rel="preload" href="/styles/critical.css" as="style" />
+<link rel="preload" href="/scripts/main.js" as="script" />
+```
+
+### `prefetch`
+
+Fetches a resource likely needed for a **future navigation** at low priority, in browser idle time.
+
+```html
+<link rel="prefetch" href="/next-page.html" as="document" />
+<link rel="prefetch" href="/images/hero-next.webp" as="image" />
+```
 
 ## Parsing and Rendering
 
@@ -62,7 +96,17 @@ There should always be a `favicon.ico` in the root directory, even if you prefer
 
 ## Meta
 
-TODO
+Common `<meta>` tags for SEO and sharing.
+
+```html
+<meta name="title" content="Page Title" />
+<meta name="description" content="A concise description of the page, ideally under 160 characters." />
+<meta name="author" content="Your Name" />
+<meta name="keywords" content="keyword1, keyword2" />
+<meta name="robots" content="index, follow" />
+<meta name="theme-color" content="#FFFFFF" media="(prefers-color-scheme: light)" />
+<meta name="theme-color" content="#000000" media="(prefers-color-scheme: dark)" />
+```
 
 ### Facebook / Open Graph
 
@@ -129,6 +173,12 @@ Scripts that must be in `<head>` should always be placed at the bottom of it to 
   <link rel="icon" href="" sizes="" type="" />
   <link rel="icon" href="/favicon.svg" sizes="any" type="image/svg+xml" />
   <link rel="manifest" href="/site.webmanifest" />
+
+  <!-- Resource Hints -->
+  <link rel="preconnect" href="" />
+  <link rel="dns-prefetch" href="" />
+  <link rel="preload" href="" as="" />
+  <link rel="prefetch" href="" as="" />
 
   <!-- Stylesheets -->
   <link rel="stylesheet" href="" type="text/css" integrity="" />


### PR DESCRIPTION
Adds a Resource Hints section covering preconnect, dns-prefetch,
preload, and prefetch with usage examples. Also fills in the Meta
section with common SEO tags. Updates the "Put Together" template
to include resource hints in the correct position.

https://claude.ai/code/session_01WBaK8WNEUZHnFKeA63zXt6